### PR TITLE
FIX - init being called to soon on backpress to view

### DIFF
--- a/library/src/main/java/com/prolificinteractive/heimdall/PasswordValidationView.java
+++ b/library/src/main/java/com/prolificinteractive/heimdall/PasswordValidationView.java
@@ -54,7 +54,6 @@ public class PasswordValidationView extends LinearLayout
     setupAttributes(attrs);
   }
 
-
   @Override public void onMatch(ValidationCheck check) {
     adapter.setMatch(check);
   }


### PR DESCRIPTION
Changing where init takes place.  onAttachedToWindow can happen before the items are configured in the case of a back press to the fragment it is in.